### PR TITLE
Future Option to Post to Steemit and Upvote

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ What's needed to begin?
 - Deduct DOGE amount from player's total
 - @steemcloud account send 0.001 STEEM to player Steem account with Memo (Steem Cloud Reward)
 - INVEST button converts to countdown CLOCK (23:59)
+  - Additionally when Steem Power is sufficient, an option to POST the investment to Steemit can be added with a 30% Upvote from the @steemcloud account. Upvote decreases by 0.5% every time Voting Power falls under 75% to adjust for increased number of players.
 - 24 hours later player repeats 
 - Level 1 Complete
 


### PR DESCRIPTION
When the @steemcloud account has an adequate amount of Steem Power, the game can offer upvotes to players by posting the investment made for that day and upvoting it. One post per day to begin with. The initial upvote would be high if there are a few players, but would need to decrease if number of users increases to the point of causing the Voting Power to fall under 75%.  